### PR TITLE
refactor: Add HuskSync support for player statistics retrieval and update async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,113 @@
+# User-specific stuff
+.idea/
+
+*.iml
+*.ipr
+*.iws
+
+# IntelliJ
+out/
+
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+target/
+
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+.flattened-pom.xml
+
+# Common working directory
+run/

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -175,6 +175,10 @@
       <id>placeholderapi</id>
       <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
     </repository>
+    <repository>
+      <id>william278.net</id>
+      <url>https://repo.william278.net/releases</url>
+    </repository>
   </repositories>
   <dependencies>
     <dependency>
@@ -208,6 +212,12 @@
       <artifactId>annotations</artifactId>
       <version>24.0.1</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.william278.husksync</groupId>
+      <artifactId>husksync-bukkit</artifactId>
+      <version>3.8.7+1.21.8</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
             <id>placeholderapi</id> <!-- Placeholder API -->
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+
+        <repository>
+            <id>william278.net</id> <!-- HuskSync -->
+            <url>https://repo.william278.net/releases</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -141,6 +146,13 @@
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>24.0.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.william278.husksync</groupId>
+            <artifactId>husksync-bukkit</artifactId>
+            <version>3.8.7+1.21.8</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/artemis/the/gr8/playerstats/api/StatManager.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/api/StatManager.java
@@ -1,6 +1,7 @@
 package com.artemis.the.gr8.playerstats.api;
 
 import java.util.LinkedHashMap;
+import java.util.concurrent.CompletableFuture;
 
 public interface StatManager {
 
@@ -31,7 +32,7 @@ public interface StatManager {
      * @see PlayerStats
      * @see StatResult
      */
-    StatResult<Integer> executePlayerStatRequest(StatRequest<Integer> request);
+    CompletableFuture<StatResult<Integer>> executePlayerStatRequest(StatRequest<Integer> request);
 
     /** Gets a RequestGenerator that can be used to create a ServerStatRequest.
      * This RequestGenerator will make sure all default settings
@@ -49,7 +50,7 @@ public interface StatManager {
      * @see PlayerStats
      * @see StatResult
      */
-    StatResult<Long> executeServerStatRequest(StatRequest<Long> request);
+    CompletableFuture<StatResult<Long>> executeServerStatRequest(StatRequest<Long> request);
 
     /** Gets a RequestGenerator that can be used to create a TopStatRequest
      * for a top-list of the specified size. This RequestGenerator will
@@ -76,5 +77,5 @@ public interface StatManager {
      * @see PlayerStats
      * @see StatResult
      */
-    StatResult<LinkedHashMap<String, Integer>> executeTopRequest(StatRequest<LinkedHashMap<String, Integer>> request);
+    CompletableFuture<StatResult<LinkedHashMap<String, Integer>>> executeTopRequest(StatRequest<LinkedHashMap<String, Integer>> request);
 }

--- a/src/main/java/com/artemis/the/gr8/playerstats/core/multithreading/StatThread.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/multithreading/StatThread.java
@@ -55,10 +55,11 @@ final class StatThread extends Thread {
         }
 
         try {
-            StatResult<?> result = StatRequestManager.execute(statRequest);
-            outputManager.sendToCommandSender(statRequester, result.formattedComponent());
-        }
-        catch (ConcurrentModificationException e) {
+            StatRequestManager.execute(statRequest).thenAccept(result -> {
+                StatResult<?> statResult = (StatResult<?>) result; // I really shouldn't do this.
+                outputManager.sendToCommandSender(statRequester, statResult.formattedComponent());
+            });
+        } catch (ConcurrentModificationException e) {
             if (!statRequest.getSettings().isConsoleSender()) {
                 outputManager.sendFeedbackMsg(statRequester, StandardMessage.UNKNOWN_ERROR);
             }

--- a/src/main/java/com/artemis/the/gr8/playerstats/core/statistic/HuskSyncProcessor.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/statistic/HuskSyncProcessor.java
@@ -10,10 +10,15 @@ import com.artemis.the.gr8.playerstats.core.sharing.ShareManager;
 import com.artemis.the.gr8.playerstats.core.utils.MyLogger;
 import com.artemis.the.gr8.playerstats.core.utils.OfflinePlayerHandler;
 import net.kyori.adventure.text.TextComponent;
+import net.william278.husksync.api.HuskSyncAPI;
+import net.william278.husksync.data.Data;
+import net.william278.husksync.data.DataSnapshot;
+import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -21,30 +26,39 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 
-final class BukkitProcessor extends RequestProcessor {
+final class HuskSyncProcessor extends RequestProcessor {
 
     private final OutputManager outputManager;
     private final ConfigHandler config;
     private final ShareManager shareManager;
     private final OfflinePlayerHandler offlinePlayerHandler;
 
-    public BukkitProcessor(OutputManager outputManager) {
+    private final HuskSyncAPI huskSyncAPI;
+
+    public HuskSyncProcessor(OutputManager outputManager) {
         this.outputManager = outputManager;
 
         config = ConfigHandler.getInstance();
         shareManager = ShareManager.getInstance();
         offlinePlayerHandler = OfflinePlayerHandler.getInstance();
+        huskSyncAPI = HuskSyncAPI.getInstance();
     }
 
     @Override
     public @NotNull CompletableFuture<StatResult<Integer>> processPlayerRequest(StatRequest<?> playerStatRequest) {
         StatRequest.Settings requestSettings = playerStatRequest.getSettings();
-        int stat = getPlayerStat(requestSettings);
-        FormattingFunction formattingFunction = outputManager.formatPlayerStat(requestSettings, stat);
-        TextComponent formattedResult = processFunction(requestSettings.getCommandSender(), formattingFunction);
-        String resultAsString = outputManager.textComponentToString(formattedResult);
 
-        return CompletableFuture.completedFuture(new StatResult<>(stat, formattedResult, resultAsString));
+        CompletableFuture<StatResult<Integer>> future = new CompletableFuture<>();
+
+        getPlayerStatHs(requestSettings).thenAccept(stat -> {
+            FormattingFunction formattingFunction = outputManager.formatPlayerStat(requestSettings, stat);
+            TextComponent formattedResult = processFunction(requestSettings.getCommandSender(), formattingFunction);
+            String resultAsString = outputManager.textComponentToString(formattedResult);
+
+            future.complete(new StatResult<>(stat, formattedResult, resultAsString));
+        });
+
+        return future;
     }
 
     @Override
@@ -69,7 +83,7 @@ final class BukkitProcessor extends RequestProcessor {
         return CompletableFuture.completedFuture(new StatResult<>(stats, formattedResult, resultAsString));
     }
 
-    private int getPlayerStat(@NotNull StatRequest.Settings requestSettings) {
+    private CompletableFuture<Integer> getPlayerStatHs(@NotNull StatRequest.Settings requestSettings) {
         OfflinePlayer player;
         if (offlinePlayerHandler.isExcludedPlayer(requestSettings.getPlayerName()) &&
                 config.allowPlayerLookupsForExcludedPlayers()) {
@@ -77,12 +91,60 @@ final class BukkitProcessor extends RequestProcessor {
         } else {
             player = offlinePlayerHandler.getIncludedOfflinePlayer(requestSettings.getPlayerName());
         }
+
+        UUID uuid = player.getUniqueId();
+
+        CompletableFuture<Integer> completableFuture = new CompletableFuture<>();
+
+        huskSyncAPI.getUser(uuid).thenAccept(optionalUser -> {
+            if (optionalUser.isEmpty()) {
+                completableFuture.complete(-1);
+                return;
+            }
+
+            huskSyncAPI.getCurrentData(optionalUser.get()).thenAccept(optionalSnapshot -> {
+                if (optionalSnapshot.isEmpty()) {
+                    completableFuture.complete(-1);
+                    return;
+                }
+
+                DataSnapshot.Unpacked snapshot = optionalSnapshot.get();
+                Optional<Data.Statistics> optionalStatistics = snapshot.getStatistics();
+                if (optionalStatistics.isEmpty()) {
+                    completableFuture.complete(-1);
+                    return;
+                }
+
+                Data.Statistics statistics = optionalStatistics.get();
+                completableFuture.complete(huskStatProcessor(statistics, requestSettings));
+            });
+
+        });
+
+        return completableFuture;
+    }
+
+
+    private int huskStatProcessor(Data.Statistics huskStats, StatRequest.Settings requestSettings) {
+        NamespacedKey nsKey = requestSettings.getStatistic().getKey();
+        String key = nsKey.getKey();
+
+        MyLogger.logLowLevelMsg("Requested main-stat: " + key);
+        MyLogger.logLowLevelMsg("Statistic type: " + requestSettings.getStatistic().getType().name());
+
         return switch (requestSettings.getStatistic().getType()) {
-            case UNTYPED -> player.getStatistic(requestSettings.getStatistic());
-            case ENTITY -> player.getStatistic(requestSettings.getStatistic(), requestSettings.getEntity());
-            case BLOCK -> player.getStatistic(requestSettings.getStatistic(), requestSettings.getBlock());
-            case ITEM -> player.getStatistic(requestSettings.getStatistic(), requestSettings.getItem());
+            case UNTYPED -> huskStats.getGenericStatistics().get(key);
+            case ENTITY ->
+                    getStatisticsSafetyValue(huskStats.getEntityStatistics().get(key), requestSettings.getEntity().getName());
+            case BLOCK ->
+                    getStatisticsSafetyValue(huskStats.getBlockStatistics().get(key), requestSettings.getBlock().name().toLowerCase(Locale.ROOT));
+            case ITEM ->
+                    getStatisticsSafetyValue(huskStats.getItemStatistics().get(key), requestSettings.getItem().name().toLowerCase(Locale.ROOT));
         };
+    }
+
+    private int getStatisticsSafetyValue(Map<String, Integer> statistics, String nameKey) {
+        return statistics.getOrDefault(nameKey, 0);
     }
 
     private long getServerStat(StatRequest.Settings requestSettings) {

--- a/src/main/java/com/artemis/the/gr8/playerstats/core/statistic/RequestProcessor.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/statistic/RequestProcessor.java
@@ -5,12 +5,13 @@ import com.artemis.the.gr8.playerstats.api.StatResult;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.LinkedHashMap;
+import java.util.concurrent.CompletableFuture;
 
 public abstract class RequestProcessor {
 
-    abstract @NotNull StatResult<Integer> processPlayerRequest(StatRequest<?> playerStatRequest);
+    abstract @NotNull CompletableFuture<StatResult<Integer>> processPlayerRequest(StatRequest<?> playerStatRequest);
 
-    abstract @NotNull StatResult<Long> processServerRequest(StatRequest<?> serverStatRequest);
+    abstract @NotNull CompletableFuture<StatResult<Long>> processServerRequest(StatRequest<?> serverStatRequest);
 
-    abstract @NotNull StatResult<LinkedHashMap<String, Integer>> processTopRequest(StatRequest<?> topStatRequest);
+    abstract @NotNull CompletableFuture<StatResult<LinkedHashMap<String, Integer>>> processTopRequest(StatRequest<?> topStatRequest);
 }

--- a/src/main/java/com/artemis/the/gr8/playerstats/core/statistic/StatRequestManager.java
+++ b/src/main/java/com/artemis/the/gr8/playerstats/core/statistic/StatRequestManager.java
@@ -6,12 +6,15 @@ import com.artemis.the.gr8.playerstats.api.StatRequest;
 import com.artemis.the.gr8.playerstats.api.StatResult;
 import com.artemis.the.gr8.playerstats.core.Main;
 import com.artemis.the.gr8.playerstats.core.msg.OutputManager;
+import com.artemis.the.gr8.playerstats.core.utils.MyLogger;
 import com.artemis.the.gr8.playerstats.core.utils.OfflinePlayerHandler;
 import com.artemis.the.gr8.playerstats.core.utils.Reloadable;
+import org.bukkit.Bukkit;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Turns user input into a {@link StatRequest} that can be
@@ -35,10 +38,20 @@ public final class StatRequestManager implements StatManager, Reloadable {
 
     private @NotNull RequestProcessor getProcessor() {
         OutputManager outputManager = OutputManager.getInstance();
+
+        boolean huskSyncAvailable = Bukkit.getPluginManager().getPlugin("HuskSync") != null;
+
+        if (huskSyncAvailable) {
+            MyLogger.logLowLevelMsg("HuskSync detected, using HuskSync for player data retrieval.");
+            return new HuskSyncProcessor(outputManager);
+        }
+
+        MyLogger.logLowLevelMsg("Using Bukkit API for player data retrieval.");
         return new BukkitProcessor(outputManager);
     }
 
-    public static StatResult<?> execute(@NotNull StatRequest<?> request) {
+    // TODO: This is not a good type declaration. Change it later.
+    public static @NotNull CompletableFuture<?> execute(@NotNull StatRequest<?> request) {
         return switch (request.getSettings().getTarget()) {
             case PLAYER -> processor.processPlayerRequest(request);
             case SERVER -> processor.processServerRequest(request);
@@ -58,7 +71,7 @@ public final class StatRequestManager implements StatManager, Reloadable {
     }
 
     @Override
-    public @NotNull StatResult<Integer> executePlayerStatRequest(@NotNull StatRequest<Integer> request) {
+    public @NotNull CompletableFuture<StatResult<Integer>> executePlayerStatRequest(@NotNull StatRequest<Integer> request) {
         return processor.processPlayerRequest(request);
     }
 
@@ -69,7 +82,7 @@ public final class StatRequestManager implements StatManager, Reloadable {
     }
 
     @Override
-    public @NotNull StatResult<Long> executeServerStatRequest(@NotNull StatRequest<Long> request) {
+    public @NotNull CompletableFuture<StatResult<Long>> executeServerStatRequest(@NotNull StatRequest<Long> request) {
         return processor.processServerRequest(request);
     }
 
@@ -86,7 +99,7 @@ public final class StatRequestManager implements StatManager, Reloadable {
     }
 
     @Override
-    public @NotNull StatResult<LinkedHashMap<String, Integer>> executeTopRequest(@NotNull StatRequest<LinkedHashMap<String, Integer>> request) {
+    public @NotNull CompletableFuture<StatResult<LinkedHashMap<String, Integer>>> executeTopRequest(@NotNull StatRequest<LinkedHashMap<String, Integer>> request) {
         return processor.processTopRequest(request);
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,6 +7,7 @@ description: adds commands to view player statistics in chat
 author: Artemis_the_gr8
 softdepend:
   - PlaceholderAPI
+  - HuskSync
 commands:
   statistic:
     aliases:


### PR DESCRIPTION
Honestly, this PR includes some breaking changes.

I found the `RequestProcessor` class in the source code and thought you might have anticipated the potential need for adapting to other data sources in the future. So, I went ahead and refactored `StatResult`.

To accommodate potential asynchronous results, I wrapped `StatResult<?>` with a `CompletableFuture`. This will make plugins that depend on `PlayerStats` incompatible (maybe a deprecation warning would be appropriate).

`HuskSync` is a 'modern, cross-server player data synchronization system...' and it's currently really useful on the proxy server. It works well on my server. When I installed `PlayerStats` on the lobby server, stats generated on the survival server weren't syncing to Bukkit in real-time through this plugin. The plugin has an internal communication mechanism that almost instantly broadcasts stats from one server to others.

In this PR, I created a new processor to pull real-time data from `HuskSync`.

(I’m not a native English speaker, so the above translation might contain errors. Thanks for understanding!)
